### PR TITLE
Using tracert to make trace in windows systems

### DIFF
--- a/src/node_modules/trace/index.js
+++ b/src/node_modules/trace/index.js
@@ -1,6 +1,7 @@
 var config = require('config')
 var url = require('url')
 var exec = require('child_process').exec
+var os = require('os')
 
 function parseHops (hops) {
   var result = []
@@ -16,7 +17,7 @@ function parseHops (hops) {
     if (neutral) {
       neutral = false
     } else {
-      if (hops[idx + 1] !== 'ms') {
+      if (hops[idx + 1] !== 'ms' && hops[idx + 1] !== undefined) {
         if (idx !== 0) { saveHop() }
         hop.fqdn = item
         hop.ip = hops[idx + 1].replace(/\(/, '').replace(/\)/, '')
@@ -75,9 +76,14 @@ function runTrace (opts, callback) {
   local.uri = opts.url || opts.uri
   local.host = url.parse(local.uri).host
   local.timeout = opts.timeout || config.trace.timeout
-  local.cmd = 'traceroute -w ' + local.timeout +
+  if (os.type === 'Windows_NT') {
+    local.cmd = 'tracert -w ' + local.timeout +
     ' ' + local.host
-
+  } else {
+    local.cmd = 'traceroute -w ' + local.timeout +
+    ' ' + local.host    
+  }
+  
   exec(local.cmd, function (err, stdout) {
     if (err) { return callback(err) }
 

--- a/src/node_modules/trace/index.js
+++ b/src/node_modules/trace/index.js
@@ -76,7 +76,7 @@ function runTrace (opts, callback) {
   local.uri = opts.url || opts.uri
   local.host = url.parse(local.uri).host
   local.timeout = opts.timeout || config.trace.timeout
-  if (os.type === 'Windows_NT') {
+  if (os.type() === 'Windows_NT') {
     local.cmd = 'tracert -w ' + local.timeout +
     ' ' + local.host
   } else {


### PR DESCRIPTION
With these changes the command to make trace will vary depending of the OS. If is windows will use tracert and in other system traceroute. 
And a extra condition in the parseHops function will prevent trying string methods at undefined variables
